### PR TITLE
Fix foreground

### DIFF
--- a/mechanoid/src/main/java/com/robotoworks/mechanoid/Mechanoid.java
+++ b/mechanoid/src/main/java/com/robotoworks/mechanoid/Mechanoid.java
@@ -19,6 +19,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.util.Log;
 
 import com.robotoworks.mechanoid.db.SQuery;
 import com.robotoworks.mechanoid.ops.OpsInitializer;
@@ -47,7 +48,19 @@ public class Mechanoid {
 
     public static void startService(Intent intent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            get().mApplicationContext.startForegroundService(intent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                try {
+                    get().mApplicationContext.startForegroundService(intent);
+                } catch (IllegalStateException e) {
+                    // ForegroundServiceStartNotAllowedException (API 31+): app is in the background
+                    // and not allowed to start a foreground service. Let it propagate so callers
+                    // can clean up any pending-request bookkeeping.
+                    Log.w("Mechanoid", "startForegroundService not allowed: " + e.getMessage());
+                    throw e;
+                }
+            } else {
+                get().mApplicationContext.startForegroundService(intent);
+            }
         } else {
             get().mApplicationContext.startService(intent);
         }

--- a/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationService.java
+++ b/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationService.java
@@ -114,7 +114,19 @@ public abstract class OperationService extends Service {
                         .build();
                 //  .setColor(ContextCompat.getColor(this, R.color.colorPrimary));
 
-                startForeground(1, notification);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    try {
+                        startForeground(1, notification);
+                    } catch (IllegalStateException e) {
+                        // ForegroundServiceStartNotAllowedException: app is in the background and
+                        // the OS has rejected this foreground service type (e.g. dataSync from BOOT_COMPLETED).
+                        Log.w(mLogTag, "startForeground not allowed, stopping service: " + e.getMessage());
+                        stopSelf(startId);
+                        return START_NOT_STICKY;
+                    }
+                } else {
+                    startForeground(1, notification);
+                }
             }
 
             intent.putExtra(EXTRA_START_ID, startId);

--- a/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
+++ b/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
@@ -22,10 +22,12 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ServiceInfo;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Messenger;
+import android.util.Log;
 import android.util.SparseArray;
 
 import com.robotoworks.mechanoid.Mechanoid;
@@ -303,7 +305,17 @@ public class OperationServiceBridge {
             mPausedRequests.put(id, clonedIntent);
         } else {
             mPendingRequests.put(id, clonedIntent);
-            Mechanoid.startService(clonedIntent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                try {
+                    Mechanoid.startService(clonedIntent);
+                } catch (IllegalStateException e) {
+                    Log.w("OperationServiceBridge", "execute: foreground service not allowed, dropping request " + id);
+                    mPendingRequests.delete(id);
+                    return -1;
+                }
+            } else {
+                Mechanoid.startService(clonedIntent);
+            }
         }
 
         return id;
@@ -335,7 +347,17 @@ public class OperationServiceBridge {
             mPausedRequests.put(id, batchIntent);
         } else {
             mPendingRequests.put(id, batchIntent);
-            Mechanoid.startService(batchIntent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                try {
+                    Mechanoid.startService(batchIntent);
+                } catch (IllegalStateException e) {
+                    Log.w("OperationServiceBridge", "executeBatch: foreground service not allowed, dropping request " + id);
+                    mPendingRequests.delete(id);
+                    return -1;
+                }
+            } else {
+                Mechanoid.startService(batchIntent);
+            }
         }
 
         return id;
@@ -356,10 +378,20 @@ public class OperationServiceBridge {
 
             for (int i = 0; i < mPausedRequests.size(); i++) {
                 Intent request = mPausedRequests.valueAt(i);
+                int pausedId = mPausedRequests.keyAt(i);
 
-                mPendingRequests.put(mPausedRequests.keyAt(i), request);
+                mPendingRequests.put(pausedId, request);
 
-                Mechanoid.startService(request);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    try {
+                        Mechanoid.startService(request);
+                    } catch (IllegalStateException e) {
+                        Log.w("OperationServiceBridge", "pause/resume: foreground service not allowed, dropping request " + pausedId);
+                        mPendingRequests.delete(pausedId);
+                    }
+                } else {
+                    Mechanoid.startService(request);
+                }
             }
 
             mPausedRequests.clear();


### PR DESCRIPTION
Wraps startForeground() in a try/catch on API 31+. On failure (e.g. dataSync rejected from BOOT_COMPLETED), calls stopSelf() and returns START_NOT_STICKY — stopping the service cleanly without a crash or a restart loop.